### PR TITLE
Fix wildcard imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Pred spustením je projekt nutné nainštalovať (napr. vo virtualenv)
 * `pip install .`
 * alebo `pip install -e .` pre tzv. "editable" inštaláciu
 
+Instalace dodatečných závislostí vhodných pro vývoj:
+* `pip install -e .[dev]`
+
 Spustenie je následne možné pomocou jedného z príkazov:
 * `spef`
 * `python -m spef`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,13 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "black"
+    "black",
+    "types-pyyaml",
+    "types-pygments",
+    "pylint",
 ]
 test = [
-    "pytest"
+    "pytest",
 ]
 
 [project.scripts]

--- a/spef/controls/control.py
+++ b/spef/controls/control.py
@@ -1,7 +1,6 @@
 import curses
 
-from spef.controls.functions import *
-from spef.utils.logger import *
+import spef.controls.functions as func
 
 
 class Control:
@@ -27,11 +26,11 @@ class Control:
         data = []
         # filter
         filter_main_functions = {
-            SHOW_HELP: "help",
-            AGGREGATE_FILTER: "aggregate",
-            REMOVE_FILTER: "remove all filters",
-            EXIT_FILTER: "exit filter",
-            EXIT_PROGRAM: "exit",
+            func.SHOW_HELP: "help",
+            func.AGGREGATE_FILTER: "aggregate",
+            func.REMOVE_FILTER: "remove all filters",
+            func.EXIT_FILTER: "exit filter",
+            func.EXIT_PROGRAM: "exit",
         }
         filter_dict_funcions = self.filter_management
         data.append(("F", filter_main_functions, filter_dict_funcions))
@@ -40,14 +39,14 @@ class Control:
         view_switch = "off" if env.quick_view else "on"
         logs_switch = "hide" if env.show_logs else "show"
         brows_main_functions = {
-            SHOW_HELP: "help",
-            OPEN_MENU: "menu",
-            QUICK_VIEW_ON_OFF: f"quick view {view_switch}",
-            SHOW_OR_HIDE_LOGS: f"{logs_switch} logs",
-            OPEN_FILE: "edit",
-            GO_TO_TAGS: "go to tags",
-            DELETE_FILE: "delete",
-            EXIT_PROGRAM: "exit",
+            func.SHOW_HELP: "help",
+            func.OPEN_MENU: "menu",
+            func.QUICK_VIEW_ON_OFF: f"quick view {view_switch}",
+            func.SHOW_OR_HIDE_LOGS: f"{logs_switch} logs",
+            func.OPEN_FILE: "edit",
+            func.GO_TO_TAGS: "go to tags",
+            func.DELETE_FILE: "delete",
+            func.EXIT_PROGRAM: "exit",
         }
         brows_dict_funcions = self.directory_brows
         data.append(("B", brows_main_functions, brows_dict_funcions))
@@ -56,17 +55,17 @@ class Control:
         tags_switch = "hide" if env.show_tags else "show"
         lines_switch = "hide" if env.line_numbers else "show"
         view_main_functions = {
-            SHOW_HELP: "help",
-            SAVE_FILE: "save",
-            SHOW_OR_HIDE_TAGS: f"{tags_switch} tags",
-            SHOW_OR_HIDE_LINE_NUMBERS: f"{lines_switch} lines",
-            SHOW_OR_HIDE_NOTE_HIGHLIGHT: f"note highlight",
-            OPEN_NOTE_MANAGEMENT: "note mgmt",
-            RELOAD_FILE_FROM_LAST_SAVE: "reload",
-            SHOW_TYPICAL_NOTES: "show typical notes",
-            SET_MANAGE_FILE_MODE: "manage file",
-            SET_EDIT_FILE_MODE: "edit file",
-            EXIT_PROGRAM: "exit",
+            func.SHOW_HELP: "help",
+            func.SAVE_FILE: "save",
+            func.SHOW_OR_HIDE_TAGS: f"{tags_switch} tags",
+            func.SHOW_OR_HIDE_LINE_NUMBERS: f"{lines_switch} lines",
+            func.SHOW_OR_HIDE_NOTE_HIGHLIGHT: f"note highlight",
+            func.OPEN_NOTE_MANAGEMENT: "note mgmt",
+            func.RELOAD_FILE_FROM_LAST_SAVE: "reload",
+            func.SHOW_TYPICAL_NOTES: "show typical notes",
+            func.SET_MANAGE_FILE_MODE: "manage file",
+            func.SET_EDIT_FILE_MODE: "edit file",
+            func.EXIT_PROGRAM: "exit",
         }
         file_dict_funcions = self.file_edit.copy()
         file_dict_funcions.update(self.file_management)
@@ -74,11 +73,11 @@ class Control:
 
         # tags
         tag_main_functions = {
-            SHOW_HELP: "help",
-            EDIT_TAG: "edit tag",
-            ADD_TAG: "new tag",
-            DELETE_TAG: "delete",
-            EXIT_PROGRAM: "exit",
+            func.SHOW_HELP: "help",
+            func.EDIT_TAG: "edit tag",
+            func.ADD_TAG: "new tag",
+            func.DELETE_TAG: "delete",
+            func.EXIT_PROGRAM: "exit",
         }
         tag_dict_funcions = self.tag_management
         data.append(("T", tag_main_functions, tag_dict_funcions))
@@ -93,25 +92,25 @@ class Control:
                 if env.report.data[env.windows.notes.cursor.row].is_typical(env):
                     typical_switch = "unsave from"
         note_main_functions = {
-            SHOW_HELP: "help",
-            EDIT_NOTE: "edit note",
-            SHOW_TYPICAL_NOTES: "show typical notes",
-            GO_TO_NOTE: "go to",
-            SAVE_AS_TYPICAL_NOTE: f"{typical_switch} typical",
-            DELETE_NOTE: "delete",
-            ADD_CUSTOM_NOTE: "add custom note",
-            EXIT_NOTES: "exit note mgmt",
-            EXIT_PROGRAM: "exit",
+            func.SHOW_HELP: "help",
+            func.EDIT_NOTE: "edit note",
+            func.SHOW_TYPICAL_NOTES: "show typical notes",
+            func.GO_TO_NOTE: "go to",
+            func.SAVE_AS_TYPICAL_NOTE: f"{typical_switch} typical",
+            func.DELETE_NOTE: "delete",
+            func.ADD_CUSTOM_NOTE: "add custom note",
+            func.EXIT_NOTES: "exit note mgmt",
+            func.EXIT_PROGRAM: "exit",
         }
         note_dict_funcions = self.note_management
         data.append(("N", note_main_functions, note_dict_funcions))
 
         # logs
         logs_main_functions = {
-            SHOW_HELP: "help",
-            OPEN_FILE: "open logs file",
-            CLEAR_LOG: "clear logs file",
-            EXIT_PROGRAM: "exit",
+            func.SHOW_HELP: "help",
+            func.OPEN_FILE: "open logs file",
+            func.CLEAR_LOG: "clear logs file",
+            func.EXIT_PROGRAM: "exit",
         }
         logs_dict_funcions = self.user_logs
         data.append(("L", logs_main_functions, logs_dict_funcions))
@@ -150,9 +149,9 @@ class Control:
             brows_dict_funcions = self.directory_brows
             brows_key, logs_key = None, None
             for k, v in brows_dict_funcions.items():
-                if QUICK_VIEW_ON_OFF == v:
+                if func.QUICK_VIEW_ON_OFF == v:
                     brows_key = k
-                elif SHOW_OR_HIDE_LOGS == v:
+                elif func.SHOW_OR_HIDE_LOGS == v:
                     logs_key = k
             if brows_key and logs_key:
                 if brows_key in self.brows_hint:
@@ -167,9 +166,9 @@ class Control:
             file_dict_funcions.update(self.file_management)
             tag_key, line_key = None, None
             for k, v in file_dict_funcions.items():
-                if SHOW_OR_HIDE_TAGS == v:
+                if func.SHOW_OR_HIDE_TAGS == v:
                     tag_key = k
-                elif SHOW_OR_HIDE_LINE_NUMBERS == v:
+                elif func.SHOW_OR_HIDE_LINE_NUMBERS == v:
                     line_key = k
             if tag_key and line_key:
                 if tag_key in self.view_hint:
@@ -191,7 +190,7 @@ class Control:
             note_dict_funcions = self.note_management
             note_key = None
             for k, v in note_dict_funcions.items():
-                if SAVE_AS_TYPICAL_NOTE == v:
+                if func.SAVE_AS_TYPICAL_NOTE == v:
                     note_key = k
                     break
             if note_key and note_key in self.note_hint:
@@ -243,7 +242,7 @@ class Control:
 
         file_keys = {}
         for str_fce, key in file_functions.items():
-            fce = map_file_function(str_fce)
+            fce = func.map_file_function(str_fce)
             if fce is not None:
                 if isinstance(key, list):
                     for k in key:
@@ -254,7 +253,7 @@ class Control:
         # control for file edit
         edit_keys = file_keys.copy()
         for str_fce, key in edit_file_functions.items():
-            fce = map_file_function(str_fce)
+            fce = func.map_file_function(str_fce)
             if fce is not None:
                 if isinstance(key, list):
                     for k in key:
@@ -265,7 +264,7 @@ class Control:
         # control for file management
         mgmt_keys = file_keys.copy()
         for str_fce, key in manage_file_functions.items():
-            fce = map_file_function(str_fce)
+            fce = func.map_file_function(str_fce)
             if fce is not None:
                 if isinstance(key, list):
                     for k in key:
@@ -283,7 +282,7 @@ class Control:
         brows_functions.update(control["arrows"])
         keys = {}
         for str_fce, key in brows_functions.items():
-            fce = map_brows_function(str_fce)
+            fce = func.map_brows_function(str_fce)
             if fce is not None:
                 if isinstance(key, list):
                     for k in key:
@@ -299,7 +298,7 @@ class Control:
         tags_functions.update(control["arrows"])
         keys = {}
         for str_fce, key in tags_functions.items():
-            fce = map_tags_function(str_fce)
+            fce = func.map_tags_function(str_fce)
             if fce is not None:
                 if isinstance(key, list):
                     for k in key:
@@ -315,7 +314,7 @@ class Control:
         notes_functions.update(control["arrows"])
         keys = {}
         for str_fce, key in notes_functions.items():
-            fce = map_notes_function(str_fce)
+            fce = func.map_notes_function(str_fce)
             if fce is not None:
                 if isinstance(key, list):
                     for k in key:
@@ -331,7 +330,7 @@ class Control:
         filter_functions.update(control["arrows"])
         keys = {}
         for str_fce, key in filter_functions.items():
-            fce = map_filter_function(str_fce)
+            fce = func.map_filter_function(str_fce)
             if fce is not None:
                 if isinstance(key, list):
                     for k in key:
@@ -347,7 +346,7 @@ class Control:
         menu_functions.update(control["arrows"])
         keys = {}
         for str_fce, key in menu_functions.items():
-            fce = map_menu_function(str_fce)
+            fce = func.map_menu_function(str_fce)
             if fce is not None:
                 if isinstance(key, list):
                     for k in key:
@@ -363,7 +362,7 @@ class Control:
         user_input_functions.update(control["arrows"])
         keys = {}
         for str_fce, key in user_input_functions.items():
-            fce = map_user_input_function(str_fce)
+            fce = func.map_user_input_function(str_fce)
             if fce is not None:
                 if isinstance(key, list):
                     for k in key:
@@ -379,7 +378,7 @@ class Control:
         user_logs_functions.update(control["arrows"])
         keys = {}
         for str_fce, key in user_logs_functions.items():
-            fce = map_user_logs_function(str_fce)
+            fce = func.map_user_logs_function(str_fce)
             if fce is not None:
                 if isinstance(key, list):
                     for k in key:
@@ -419,7 +418,7 @@ def get_function_for_key(env, key):
     elif key == curses.ascii.TAB:
         return env.control.get_function(env, "TAB")
     elif key == curses.KEY_RESIZE:
-        return RESIZE_WIN
+        return func.RESIZE_WIN
         # return env.control.get_function(env, 'RESIZE')
     elif key == curses.KEY_UP:
         return env.control.get_function(env, "UP")

--- a/spef/main.py
+++ b/spef/main.py
@@ -11,11 +11,17 @@ import time
 import tty
 
 from spef.modules.environment import Environment
-from spef.utils.loading import *
-from spef.utils.screens import *
-from spef.utils.coloring import *
-from spef.utils.printing import *
-from spef.utils.logger import *
+from spef.utils.loading import (
+    load_config_from_file,
+    load_typical_notes_from_file,
+    load_user_logs_from_file,
+    save_typical_notes_to_file,
+    load_control_from_file,
+)
+from spef.utils.screens import create_screens_and_windows
+from spef.utils.coloring import init_color_pairs, COL_BKGD
+from spef.utils.printing import refresh_main_screens, print_hint
+from spef.utils.logger import log, TMP_DIR, LOG_FILE, DATA_DIR, USER_LOGS_FILE
 
 from spef.views.browsing import get_directory_content, directory_browsing
 from spef.views.viewing import file_viewing

--- a/spef/modules/bash.py
+++ b/spef/modules/bash.py
@@ -1,5 +1,3 @@
-from spef.utils.logger import *
-
 """
 - init setting:
 * exit_key is set to any key

--- a/spef/modules/buffer.py
+++ b/spef/modules/buffer.py
@@ -1,7 +1,5 @@
 import re
 
-from spef.utils.logger import *
-
 
 class UserInput:
     def __init__(self):

--- a/spef/modules/directory.py
+++ b/spef/modules/directory.py
@@ -1,11 +1,12 @@
 import os
 import traceback
 
-from spef.modules.project import Project
+import curses
 
-from spef.utils.loading import *
-from spef.utils.logger import *
-from spef.utils.match import *
+from spef.modules.project import Project
+from spef.utils.loading import load_proj_from_conf_file
+from spef.utils.logger import log
+from spef.utils.match import get_proj_path, is_testcase_result_dir
 from spef.utils.parsing import (
     parse_solution_info_visualization,
     parse_solution_info_predicate,

--- a/spef/modules/environment.py
+++ b/spef/modules/environment.py
@@ -1,7 +1,8 @@
 import os
 
-from spef.controls.control import *
-from spef.utils.logger import *
+from spef.controls.control import Control
+from spef.utils.logger import log
+
 
 """ modes """
 BROWS = 1

--- a/spef/modules/filter.py
+++ b/spef/modules/filter.py
@@ -3,9 +3,13 @@ import os
 import re
 import traceback
 
-from spef.utils.loading import *
-from spef.utils.logger import *
-from spef.utils.match import *
+from spef.utils.loading import get_tags_file, load_tags_from_file
+from spef.utils.logger import log
+from spef.utils.match import (
+    filter_intern_files,
+    get_root_tests_dir,
+    get_root_solution_dir,
+)
 from spef.utils.parsing import parse_tag
 
 

--- a/spef/modules/project.py
+++ b/spef/modules/project.py
@@ -2,9 +2,13 @@ import datetime
 import os
 import re
 
-from spef.utils.loading import *
-from spef.utils.logger import *
-from spef.utils.match import *
+from spef.utils.loading import (
+    load_tests_tags,
+    load_solution_tags,
+    load_user_notes_for_solution,
+    load_test_notes_for_solution,
+)
+from spef.utils.logger import log, TESTS_DIR
 
 
 class Solution:

--- a/spef/modules/report.py
+++ b/spef/modules/report.py
@@ -1,7 +1,5 @@
 import yaml
 
-from spef.utils.logger import *
-
 
 class Note:
     def __init__(self, text, row=None, col=None):

--- a/spef/modules/tags.py
+++ b/spef/modules/tags.py
@@ -1,7 +1,5 @@
 import re
 
-from spef.utils.logger import *
-
 
 """
 data = {'documentation': ['ok'],

--- a/spef/modules/window.py
+++ b/spef/modules/window.py
@@ -1,6 +1,6 @@
 import traceback
 
-from spef.utils.logger import *
+from spef.utils.logger import log
 
 
 """ curses screens (each with its specific size and position on the main screen) """

--- a/spef/styles/ncurses.py
+++ b/spef/styles/ncurses.py
@@ -1,19 +1,5 @@
 from pygments.style import Style
-from pygments.token import (
-    Keyword,
-    Name,
-    Comment,
-    String,
-    Error,
-    Text,
-    Number,
-    Operator,
-    Generic,
-    Whitespace,
-    Punctuation,
-    Other,
-    Literal,
-)
+import pygments.token as token
 
 
 """
@@ -45,45 +31,45 @@ class NcursesStyle(Style):
     # https://svn.python.org/projects/external/Pygments-1.3.1/docs/build/tokens.html
     # fmt: off
     styles = {
-        Comment: HL_GREEN,
-        Comment.Preproc: HL_PURPLE,
-        Comment.Special: HL_NORMAL,
-        Keyword: HL_BLUE,
+        token.Comment: HL_GREEN,
+        token.Comment.Preproc: HL_PURPLE,
+        token.Comment.Special: HL_NORMAL,
+        token.Keyword: HL_BLUE,
         # Keyword.Constant:          "",
         # Keyword.Declaration:       "", # var
-        Keyword.Namespace: HL_PURPLE,  # import, package
+        token.Keyword.Namespace: HL_PURPLE,  # import, package
         # Keyword.Pseudo:            "",
         # Keyword.Reserved:          "",
         # Keyword.Type:              "", # int, char
-        Name: HL_NORMAL,
-        Name.Attribute: HL_YELLOW,
-        Name.Builtin: HL_LIGHT_BLUE,  # self, this
+        token.Name: HL_NORMAL,
+        token.Name.Attribute: HL_YELLOW,
+        token.Name.Builtin: HL_LIGHT_BLUE,  # self, this
         # Name.Builtin.Pseudo:       "",
-        Name.Class: HL_CYAN,
-        Name.Constant: HL_BLUE,  # const
-        Name.Decorator: HL_YELLOW,
+        token.Name.Class: HL_CYAN,
+        token.Name.Constant: HL_BLUE,  # const
+        token.Name.Decorator: HL_YELLOW,
         # Name.Entity:               HL_LIGHT_BLUE,
-        Name.Exception: HL_CYAN,
-        Name.Function: HL_YELLOW,
+        token.Name.Exception: HL_CYAN,
+        token.Name.Function: HL_YELLOW,
         # Name.Label:                "",
         # Name.Namespace:            HL_LIGHT_BLUE, # import path or name folowing the module/namespace keyword
-        Name.Other: HL_YELLOW,
-        Name.Tag: HL_PURPLE,
-        Name.Variable: HL_LIGHT_BLUE,
-        Number: HL_PASTEL_GREEN,  # HL_PINK
-        Literal: HL_PASTEL_GREEN,  # HL_PINK
-        Literal.Date: HL_ORANGE,
-        String: HL_ORANGE,
-        String.Escape: HL_PASTEL_GREEN,  # HL_PINK
-        String.Interpol: HL_BLUE,
-        Text: HL_NORMAL,
-        Operator: HL_NORMAL,
-        Operator.Word: HL_BLUE,
-        Punctuation: HL_NORMAL,
-        Error: HL_RED,
-        Generic.Deleted: HL_PURPLE,
-        Generic.Inserted: HL_YELLOW,
-        Generic.Output: HL_BLUE,
-        Generic.Prompt: HL_PURPLE,
-        Generic.Subheading: HL_PURPLE,
+        token.Name.Other: HL_YELLOW,
+        token.Name.Tag: HL_PURPLE,
+        token.Name.Variable: HL_LIGHT_BLUE,
+        token.Number: HL_PASTEL_GREEN,  # HL_PINK
+        token.Literal: HL_PASTEL_GREEN,  # HL_PINK
+        token.Literal.Date: HL_ORANGE,
+        token.String: HL_ORANGE,
+        token.String.Escape: HL_PASTEL_GREEN,  # HL_PINK
+        token.String.Interpol: HL_BLUE,
+        token.Text: HL_NORMAL,
+        token.Operator: HL_NORMAL,
+        token.Operator.Word: HL_BLUE,
+        token.Punctuation: HL_NORMAL,
+        token.Error: HL_RED,
+        token.Generic.Deleted: HL_PURPLE,
+        token.Generic.Inserted: HL_YELLOW,
+        token.Generic.Output: HL_BLUE,
+        token.Generic.Prompt: HL_PURPLE,
+        token.Generic.Subheading: HL_PURPLE,
     }

--- a/spef/utils/highlighter.py
+++ b/spef/utils/highlighter.py
@@ -2,7 +2,6 @@ from pygments import highlight
 from pygments import lexers
 from pygments.formatter import Formatter
 
-from spef.utils.logger import *
 
 """ ======================= SYNTAX HIGHLIGHTER ========================= """
 

--- a/spef/utils/history.py
+++ b/spef/utils/history.py
@@ -2,16 +2,16 @@ import os
 import shutil
 import traceback
 
-from spef.utils.logger import *
+import spef.utils.logger as logger
 from spef.utils.loading import (
     load_testcase_tags,
-    load_testsuite_tags,
     save_tags_to_file,
+    load_testsuite_tags,
 )
 
 
 def is_test_history_in_tmp(proj_dir, test_name):
-    testcase_dir = os.path.join(proj_dir, TESTS_DIR, test_name)
+    testcase_dir = os.path.join(proj_dir, logger.TESTS_DIR, test_name)
     testcase_tags = load_testcase_tags(testcase_dir)
     if testcase_tags is not None:
         # get version of test
@@ -19,15 +19,15 @@ def is_test_history_in_tmp(proj_dir, test_name):
         version = 1 if args is None or len(args) < 1 else int(args[0])
 
         # check if tmp dir with test with actual version exists
-        tmp_test_v_dir = os.path.join(TMP_DIR, test_name, f"version_{version}")
+        tmp_test_v_dir = os.path.join(logger.TMP_DIR, test_name, f"version_{version}")
         return os.path.exists(tmp_test_v_dir) and os.path.isdir(tmp_test_v_dir)
 
 
 def history_test_removed(env, proj_dir, test_name, add_to_user_logs):
     try:
-        history_dir = os.path.join(proj_dir, HISTORY_DIR)
+        history_dir = os.path.join(proj_dir, logger.HISTORY_DIR)
 
-        testcase_dir = os.path.join(proj_dir, TESTS_DIR, test_name)
+        testcase_dir = os.path.join(proj_dir, logger.TESTS_DIR, test_name)
         testcase_tags = load_testcase_tags(testcase_dir)
         if testcase_tags is not None:
             # get version of test
@@ -54,7 +54,9 @@ def history_test_removed(env, proj_dir, test_name, add_to_user_logs):
             history_test_event(proj_dir, test_name, f"remove test (version {version})")
             return True
     except Exception as err:
-        log("history test removed | " + str(err) + " | " + str(traceback.format_exc()))
+        logger.log(
+            "history test removed | " + str(err) + " | " + str(traceback.format_exc())
+        )
     return False
 
 
@@ -66,25 +68,27 @@ def history_test_removed(env, proj_dir, test_name, add_to_user_logs):
 # return success
 def history_test_modified(env, proj_dir, test_name, add_to_user_logs):
     try:
-        history_dir = os.path.join(proj_dir, HISTORY_DIR)
+        history_dir = os.path.join(proj_dir, logger.HISTORY_DIR)
 
-        tests_dir = os.path.join(proj_dir, TESTS_DIR)
+        tests_dir = os.path.join(proj_dir, logger.TESTS_DIR)
         testcase_dir = os.path.join(tests_dir, test_name)
         testcase_tags = load_testcase_tags(testcase_dir)
         if testcase_tags is not None:
             # get version of test
             args = testcase_tags.get_args_for_tag("version")
             if args is None or len(args) < 1:
-                log("history test modified | test tags - cant find tag #version(int)")
+                logger.log(
+                    "history test modified | test tags - cant find tag #version(int)"
+                )
                 version = 1
             else:
                 version = int(args[0])
 
             # check if tmp dir with test with actual version exists
-            tmp_test_dir = os.path.join(TMP_DIR, test_name)
+            tmp_test_dir = os.path.join(logger.TMP_DIR, test_name)
             tmp_test_v_dir = os.path.join(tmp_test_dir, f"version_{version}")
             if not os.path.exists(tmp_test_v_dir) or not os.path.isdir(tmp_test_v_dir):
-                log("history test modified | test is not saved in tmp dir")
+                logger.log("history test modified | test is not saved in tmp dir")
                 return False
 
             # increment test version
@@ -99,7 +103,7 @@ def history_test_modified(env, proj_dir, test_name, add_to_user_logs):
             ):
                 os.mkdir(history_test_dir)
             if os.path.exists(history_test_v_dir):
-                log(
+                logger.log(
                     f"history test modified | test {test_name} with version {version} already exists in history!!"
                 )
                 return False
@@ -121,10 +125,12 @@ def history_test_modified(env, proj_dir, test_name, add_to_user_logs):
             # shutil.rmtree(tmp_test_v_dir)
             # log("remove tmp test dir")
         else:
-            log("history test modified | cant load test tags ")
+            logger.log("history test modified | cant load test tags ")
             return False
     except Exception as err:
-        log("history test modified | " + str(err) + " | " + str(traceback.format_exc()))
+        logger.log(
+            "history test modified | " + str(err) + " | " + str(traceback.format_exc())
+        )
         return False
 
 
@@ -135,16 +141,18 @@ def history_test_event(proj_dir, test_name, event):
     if not event:
         return
 
-    history_dir = os.path.join(proj_dir, HISTORY_DIR)
-    history_file = os.path.join(history_dir, HISTORY_FILE)
+    history_dir = os.path.join(proj_dir, logger.HISTORY_DIR)
+    history_file = os.path.join(history_dir, logger.HISTORY_FILE)
 
-    tests_dir = os.path.join(proj_dir, TESTS_DIR)
+    tests_dir = os.path.join(proj_dir, logger.TESTS_DIR)
     testsuite_tags = load_testsuite_tags(tests_dir)
     if testsuite_tags is not None:
         # get testsuite version
         args = testsuite_tags.get_args_for_tag("version")
         if args is None or len(args) < 1:
-            log("history new test | testsuite tags - cant find tag #version(int)")
+            logger.log(
+                "history new test | testsuite tags - cant find tag #version(int)"
+            )
             version = 1
         else:
             version = int(args[0])
@@ -154,7 +162,7 @@ def history_test_event(proj_dir, test_name, event):
             # tags_file = os.path.join(tests_dir, TESTSUITE_TAGS)
             # add_tag_to_file(tags_file, {"version": [version+1]})
     else:
-        log("history new test | cant load testsuite tags ")
+        logger.log("history new test | cant load testsuite tags ")
 
 
 def add_event_to_tests_history(file_path, version, test, event):

--- a/spef/utils/match.py
+++ b/spef/utils/match.py
@@ -4,7 +4,7 @@ import traceback
 import tarfile
 import zipfile
 
-from spef.utils.logger import *
+import spef.utils.logger as logger
 
 
 def filter_intern_files(path_list, keep_reports_and_tests=False):
@@ -13,7 +13,10 @@ def filter_intern_files(path_list, keep_reports_and_tests=False):
             # filter files with repport suffix or tags suffix
             result = list(
                 filter(
-                    lambda x: not x.endswith((REPORT_SUFFIX, TAGS_SUFFIX)), path_list
+                    lambda x: not x.endswith(
+                        (logger.REPORT_SUFFIX, logger.TAGS_SUFFIX)
+                    ),
+                    path_list,
                 )
             )
 
@@ -22,7 +25,7 @@ def filter_intern_files(path_list, keep_reports_and_tests=False):
                 result = list(
                     filter(
                         lambda x: not match_regex(
-                            os.path.join(".*", REPORT_DIR, ".*"), x
+                            os.path.join(".*", logger.REPORT_DIR, ".*"), x
                         ),
                         result,
                     )
@@ -30,23 +33,23 @@ def filter_intern_files(path_list, keep_reports_and_tests=False):
                 result = list(
                     filter(
                         lambda x: not match_regex(
-                            os.path.join(".*", TESTS_DIR, ".*"), x
+                            os.path.join(".*", logger.TESTS_DIR, ".*"), x
                         ),
                         result,
                     )
                 )
             return result
     except Exception as err:
-        log("filter intern files | " + str(err))
+        logger.log("filter intern files | " + str(err))
     return path_list
 
 
 def match_report_dir(path):
-    return match_regex(os.path.join(".*", REPORT_DIR, ".*"), path)
+    return match_regex(os.path.join(".*", logger.REPORT_DIR, ".*"), path)
 
 
 def match_tests_dir(path):
-    return match_regex(os.path.join(".*", TESTS_DIR, ".*"), path)
+    return match_regex(os.path.join(".*", logger.TESTS_DIR, ".*"), path)
 
 
 ############################ CHECK PATH ############################
@@ -71,11 +74,11 @@ def is_root_project_dir(path):
 
         if os.path.isdir(path):
             file_list = os.listdir(path)
-            if PROJ_CONF_FILE in file_list:
+            if logger.PROJ_CONF_FILE in file_list:
                 return True
         return False
     except Exception as err:
-        log("is root proj dir | " + str(err))
+        logger.log("is root proj dir | " + str(err))
         return False
 
 
@@ -154,7 +157,7 @@ def is_root_reports_dir(path):
             return False
 
         if os.path.isdir(path):
-            return os.path.basename(path) == REPORT_DIR
+            return os.path.basename(path) == logger.REPORT_DIR
         return False
     except:
         return False
@@ -187,7 +190,7 @@ def is_root_tests_dir(path):
             return False
 
         if os.path.isdir(path):
-            return os.path.basename(path) == TESTS_DIR
+            return os.path.basename(path) == logger.TESTS_DIR
         return False
     except:
         return False
@@ -225,7 +228,7 @@ def is_testcase_dir(path, with_check=True):
             if is_root_tests_dir(parent_dir):
                 if with_check:
                     file_list = os.listdir(path)
-                    if TEST_FILE in file_list:
+                    if logger.TEST_FILE in file_list:
                         return True
                 else:
                     return True
@@ -240,7 +243,7 @@ def is_testcase_result_dir(solution_id, path):
             return False
 
         if is_in_solution_dir(solution_id, path) and os.path.isdir(path):
-            return os.path.basename(os.path.dirname(path)) == RESULTS_SUB_DIR
+            return os.path.basename(os.path.dirname(path)) == logger.RESULTS_SUB_DIR
     except:
         return False
 
@@ -272,7 +275,7 @@ def get_parent_regex_match(reg, dir_path):
                 else:
                     cur_dir = parent_dir
     except Exception as err:
-        log(
+        logger.log(
             "get parent regex match | " + str(err) + " | " + str(traceback.format_exc())
         )
         return None
@@ -303,7 +306,7 @@ def get_proj_path(path):
                 else:
                     cur_dir = parent_dir
     except Exception as err:
-        log("get proj path | " + str(err))
+        logger.log("get proj path | " + str(err))
         return None
 
 
@@ -327,7 +330,7 @@ def get_root_solution_dir(solution_id, path):
                 else:
                     cur_dir = parent_dir
     except Exception as err:
-        log("get root solution dir | " + str(err))
+        logger.log("get root solution dir | " + str(err))
         return None
 
 
@@ -347,7 +350,7 @@ def get_root_tests_dir(path):
                 else:
                     cur_dir = parent_dir
     except Exception as err:
-        log("get root tests dir | " + str(err))
+        logger.log("get root tests dir | " + str(err))
         return None
 
 
@@ -367,7 +370,7 @@ def get_root_testcase_dir(path):
                 else:
                     cur_dir = parent_dir
     except Exception as err:
-        log("get root testcase dir | " + str(err))
+        logger.log("get root testcase dir | " + str(err))
         return None
 
 
@@ -383,7 +386,7 @@ def get_solution_files(env):
             if is_solution_file(solution_id, path):
                 result.add(path)
     else:
-        log("get_solution_files | cwd is not project root directory")
+        logger.log("get_solution_files | cwd is not project root directory")
     return list(result)
 
 
@@ -397,7 +400,7 @@ def get_solution_archives(env):
         if is_archive_file(file_name):
             solution_archives.add(file_name)
         else:
-            log(
+            logger.log(
                 "solution file but not zipfile or tarfile: "
                 + str(os.path.basename(file_name))
             )
@@ -412,12 +415,12 @@ def get_solution_archives(env):
 def get_tests_names(env, with_check=True):
     result_names = set()
     if env.cwd.proj is not None:
-        tests_dir = os.path.join(env.cwd.proj.path, TESTS_DIR)
+        tests_dir = os.path.join(env.cwd.proj.path, logger.TESTS_DIR)
         items = os.listdir(tests_dir)  # list all dirs and files in tests dir
         for item in items:
             path = os.path.join(tests_dir, item)
             if is_testcase_dir(path, with_check=with_check):
                 result_names.add(item)
     else:
-        log("get tests names | cwd is not project root directory")
+        logger.log("get tests names | cwd is not project root directory")
     return list(result_names)

--- a/spef/utils/parsing.py
+++ b/spef/utils/parsing.py
@@ -1,8 +1,8 @@
 import curses
 import re
 
-from spef.utils.coloring import *
-from spef.utils.logger import *
+import spef.utils.coloring as clr
+from spef.utils.logger import log
 from spef.utils.match import get_tests_names
 
 
@@ -156,14 +156,14 @@ def parse_solution_info_predicate(
     predicate, solution, info_for_tests=False, test_name=None
 ):
     # defined colors
-    red = curses.color_pair(COL_RED)
-    green = curses.color_pair(COL_GREEN)
-    blue = curses.color_pair(COL_BLUE)
+    red = curses.color_pair(clr.COL_RED)
+    green = curses.color_pair(clr.COL_GREEN)
+    blue = curses.color_pair(clr.COL_BLUE)
     normal = curses.A_NORMAL
-    cyan = curses.color_pair(COL_CYAN)
-    yellow = curses.color_pair(COL_YELLOW)
-    orange = curses.color_pair(COL_ORANGE)
-    pink = curses.color_pair(COL_PINK)
+    cyan = curses.color_pair(clr.COL_CYAN)
+    yellow = curses.color_pair(clr.COL_YELLOW)
+    orange = curses.color_pair(clr.COL_ORANGE)
+    pink = curses.color_pair(clr.COL_PINK)
 
     color = normal
     match = False

--- a/spef/utils/printing.py
+++ b/spef/utils/printing.py
@@ -3,7 +3,6 @@ import os
 import re
 import traceback
 
-from spef.controls.functions import *
 from spef.modules.buffer import UserInput
 from spef.utils.highlighter import parse_code
 from spef.utils.loading import (
@@ -11,8 +10,8 @@ from spef.utils.loading import (
     save_report_to_file,
     load_testcase_tags,
 )
-from spef.utils.coloring import *
-from spef.utils.logger import *
+import spef.utils.coloring as clr
+import spef.utils.logger as logger
 from spef.utils.history import history_test_modified, is_test_history_in_tmp
 from spef.utils.file import actualize_test_history_in_tmp
 
@@ -98,7 +97,7 @@ def print_help(screen, win, env, exit_mess, title, actions):
     if exit_mess:
         if len(exit_mess) >= max_cols:
             exit_mess = exit_mess[: max_cols - 1]
-        screen.addstr(line, 1, exit_mess, curses.color_pair(COL_HELP))
+        screen.addstr(line, 1, exit_mess, curses.color_pair(clr.COL_HELP))
         line += 1
     if title:
         if len(title) >= max_cols:
@@ -117,7 +116,7 @@ def print_help(screen, win, env, exit_mess, title, actions):
         # print key
         if len(key) + 3 >= max_cols:
             break
-        screen.addstr(line, 1, str(key), curses.color_pair(COL_HELP))
+        screen.addstr(line, 1, str(key), curses.color_pair(clr.COL_HELP))
 
         # print action
         action = actions[key]
@@ -177,8 +176,8 @@ def file_changes_are_saved(stdscr, env, add_to_user_logs, warning=None):
         if (env.buffer.is_saved) or (env.buffer.original_buff == env.buffer.lines):
             return True
         else:
-            curses_key, str_key = (ESC, "ESC")
-            message = warning if warning else EXIT_WITHOUT_SAVING
+            curses_key, str_key = (logger.ESC, "ESC")
+            message = warning if warning else logger.EXIT_WITHOUT_SAVING
 
             """ print warning message """
             screen = env.screens.right
@@ -201,7 +200,7 @@ def file_changes_are_saved(stdscr, env, add_to_user_logs, warning=None):
 
 def save_buffer(stdscr, env, add_to_user_logs):
     if not env.file_to_open or not env.buffer:
-        log("save buffer | missing env.file_to_open or mising env.buffer")
+        logger.log("save buffer | missing env.file_to_open or mising env.buffer")
         return
 
     save_buffer_to_file(env.file_to_open, env.buffer)
@@ -219,7 +218,7 @@ def save_buffer(stdscr, env, add_to_user_logs):
             """print warning message"""
             screen = env.screens.right
             screen.erase()
-            screen.addstr(1, 1, str(TEST_MODIFICATION), curses.A_BOLD)
+            screen.addstr(1, 1, str(logger.TEST_MODIFICATION), curses.A_BOLD)
             screen.border(0)
             screen.refresh()
 
@@ -233,7 +232,7 @@ def save_buffer(stdscr, env, add_to_user_logs):
                     env.cwd.proj.path, os.path.dirname(env.file_to_open)
                 )
             else:  # dont save to history
-                log(
+                logger.log(
                     "dont save old test version to history | will be discard after system exit"
                 )
 
@@ -334,22 +333,25 @@ def show_filter(screen, user_input, max_rows, max_cols, env):
         # show default message with example usage of filter
         empty_message = ""
         if env.is_brows_mode():
-            empty_message = EMPTY_PATH_FILTER_MESSAGE
+            empty_message = logger.EMPTY_PATH_FILTER_MESSAGE
         elif env.is_view_mode():
-            empty_message = EMPTY_CONTENT_FILTER_MESSAGE
+            empty_message = logger.EMPTY_CONTENT_FILTER_MESSAGE
         elif env.is_tag_mode():
-            empty_message = EMPTY_TAG_FILTER_MESSAGE
+            empty_message = logger.EMPTY_TAG_FILTER_MESSAGE
         empty_message += " " * (max_cols - 1 - len(empty_message))
         screen.addstr(
             max_rows,
             1,
             empty_message[: max_cols - 1],
-            curses.color_pair(COL_FILTER) | curses.A_ITALIC,
+            curses.color_pair(clr.COL_FILTER) | curses.A_ITALIC,
         )
     else:
         user_input_str += " " * (max_cols - 1 - len(user_input_str))
         screen.addstr(
-            max_rows, 1, user_input_str[: max_cols - 1], curses.color_pair(COL_FILTER)
+            max_rows,
+            1,
+            user_input_str[: max_cols - 1],
+            curses.color_pair(clr.COL_FILTER),
         )
     screen.refresh()
 
@@ -367,9 +369,9 @@ def show_directory_content(env):
     """ print borders """
     screen.erase()
     if env.is_brows_mode():
-        screen.attron(curses.color_pair(COL_BORDER))
+        screen.attron(curses.color_pair(clr.COL_BORDER))
         screen.border(0)
-        screen.attroff(curses.color_pair(COL_BORDER))
+        screen.attroff(curses.color_pair(clr.COL_BORDER))
     else:
         screen.border(0)
 
@@ -400,7 +402,7 @@ def show_directory_content(env):
                 if i > max_rows or (i == max_rows and env.path_filter_on()):
                     break
                 coloring = (
-                    curses.color_pair(COL_SELECT)
+                    curses.color_pair(clr.COL_SELECT)
                     if i + win.row_shift == win.cursor.row + 1
                     else curses.A_NORMAL
                 )
@@ -422,7 +424,7 @@ def show_directory_content(env):
                                 break
                             x = x - len(info) - 1
                             color = (
-                                curses.color_pair(COL_SELECT)
+                                curses.color_pair(clr.COL_SELECT)
                                 if i + win.row_shift == win.cursor.row + 1
                                 else col
                             )
@@ -437,7 +439,7 @@ def show_directory_content(env):
                 if i > max_rows or (i == max_rows and env.path_filter_on()):
                     break
                 coloring = (
-                    curses.color_pair(COL_SELECT)
+                    curses.color_pair(clr.COL_SELECT)
                     if i + win.row_shift == win.cursor.row + 1
                     else curses.A_NORMAL
                 )
@@ -452,7 +454,7 @@ def show_directory_content(env):
                 show_filter(screen, user_input, max_rows, max_cols, env)
 
     except Exception as err:
-        log("show directory | " + str(err) + " | " + str(traceback.format_exc()))
+        logger.log("show directory | " + str(err) + " | " + str(traceback.format_exc()))
     finally:
         screen.refresh()
 
@@ -570,9 +572,9 @@ def show_file_content(env):
     screen.erase()
     """ print border """
     if env.is_view_mode():
-        screen.attron(curses.color_pair(COL_BORDER))
+        screen.attron(curses.color_pair(clr.COL_BORDER))
         screen.border(0)
-        screen.attroff(curses.color_pair(COL_BORDER))
+        screen.attroff(curses.color_pair(clr.COL_BORDER))
     else:
         screen.border(0)
 
@@ -639,9 +641,9 @@ def show_file_content(env):
                     #  OPTION B : note highlight on line number
                     """ set color for line numbers and for line text """
                     if y + win.row_shift in colored_lines:
-                        line_num_color = curses.color_pair(COL_NOTE)
+                        line_num_color = curses.color_pair(clr.COL_NOTE)
                     else:
-                        line_num_color = curses.color_pair(COL_LINE_NUM)
+                        line_num_color = curses.color_pair(clr.COL_LINE_NUM)
 
                     text_color = curses.color_pair(style)
                     if env.specific_line_highlight is not None:
@@ -740,9 +742,9 @@ def show_file_content(env):
                     #  OPTION B : note highlight on line number
                     """ set color for line numbers and for line text """
                     if row + 1 + win.row_shift in colored_lines:
-                        line_num_color = curses.color_pair(COL_NOTE)
+                        line_num_color = curses.color_pair(clr.COL_NOTE)
                     else:
-                        line_num_color = curses.color_pair(COL_LINE_NUM)
+                        line_num_color = curses.color_pair(clr.COL_LINE_NUM)
 
                     text_color = curses.A_NORMAL
                     if env.specific_line_highlight is not None:
@@ -789,9 +791,9 @@ def show_file_content(env):
             #  OPTION B : note highlight on line number
             """set color for line numbers"""
             if 1 in colored_lines:
-                line_num_color = curses.color_pair(COL_NOTE)
+                line_num_color = curses.color_pair(clr.COL_NOTE)
             else:
-                line_num_color = curses.color_pair(COL_LINE_NUM)
+                line_num_color = curses.color_pair(clr.COL_LINE_NUM)
 
             """ print line number """
             if env.line_numbers:
@@ -821,7 +823,7 @@ def show_file_content(env):
             # show_filter(screen, user_input, max_rows, max_cols, env)
 
     except Exception as err:
-        log("show file | " + str(err) + " | " + str(traceback.format_exc()))
+        logger.log("show file | " + str(err) + " | " + str(traceback.format_exc()))
     finally:
         screen.refresh()
 
@@ -840,9 +842,9 @@ def show_tags(env):
     """ print borders """
     screen.erase()
     if env.is_tag_mode():
-        screen.attron(curses.color_pair(COL_BORDER))
+        screen.attron(curses.color_pair(clr.COL_BORDER))
         screen.border(0)
-        screen.attroff(curses.color_pair(COL_BORDER))
+        screen.attroff(curses.color_pair(clr.COL_BORDER))
     else:
         screen.border(0)
 
@@ -867,7 +869,7 @@ def show_tags(env):
 
                 """ set color """
                 if i - 1 + win.row_shift == win.cursor.row and env.is_tag_mode():
-                    coloring = curses.color_pair(COL_SELECT)
+                    coloring = curses.color_pair(clr.COL_SELECT)
                 else:
                     coloring = curses.A_NORMAL
 
@@ -887,7 +889,7 @@ def show_tags(env):
             show_filter(screen, user_input, max_rows, max_cols, env)
 
     except Exception as err:
-        log("show tags | " + str(err) + " | " + str(traceback.format_exc()))
+        logger.log("show tags | " + str(err) + " | " + str(traceback.format_exc()))
     finally:
         screen.refresh()
 
@@ -903,9 +905,9 @@ def show_notes(env):
     """ print borders """
     screen.erase()
     if env.is_notes_mode():
-        screen.attron(curses.color_pair(COL_BORDER))
+        screen.attron(curses.color_pair(clr.COL_BORDER))
         screen.border(0)
-        screen.attroff(curses.color_pair(COL_BORDER))
+        screen.attroff(curses.color_pair(clr.COL_BORDER))
     else:
         screen.border(0)
 
@@ -941,7 +943,7 @@ def show_notes(env):
 
                 """ set color """
                 if row + win.row_shift == win.cursor.row and env.is_notes_mode():
-                    color = curses.color_pair(COL_SELECT)
+                    color = curses.color_pair(clr.COL_SELECT)
                 else:
                     color = curses.A_NORMAL
 
@@ -949,7 +951,7 @@ def show_notes(env):
                 screen.addstr(row + 1, 1, line, color)
 
     except Exception as err:
-        log("show notes | " + str(err) + " | " + str(traceback.format_exc()))
+        logger.log("show notes | " + str(err) + " | " + str(traceback.format_exc()))
     finally:
         screen.refresh()
 
@@ -981,9 +983,9 @@ def show_menu(
 
                 """ set color """
                 if row + win.row_shift == win.cursor.row + 1:  # +1
-                    coloring = curses.color_pair(COL_SELECT)
+                    coloring = curses.color_pair(clr.COL_SELECT)
                 elif row + win.row_shift - 1 in selected:
-                    coloring = curses.color_pair(COL_SELECT)
+                    coloring = curses.color_pair(clr.COL_SELECT)
                 else:
                     coloring = curses.A_NORMAL
 
@@ -991,7 +993,7 @@ def show_menu(
                     key = keys[row - 1 + win.row_shift]
                 else:
                     key = row + win.row_shift
-                screen.addstr(row + 1, 1, str(key), curses.color_pair(COL_HELP))
+                screen.addstr(row + 1, 1, str(key), curses.color_pair(clr.COL_HELP))
                 shift = len(str(key)) + 1
                 screen.addstr(
                     row + 1, 1 + shift, str(option[: max_cols - (1 + shift)]), coloring
@@ -1006,7 +1008,7 @@ def show_menu(
             )
 
     except Exception as err:
-        log("show menu | " + str(err) + " | " + str(traceback.format_exc()))
+        logger.log("show menu | " + str(err) + " | " + str(traceback.format_exc()))
     finally:
         screen.refresh()
 
@@ -1024,9 +1026,9 @@ def show_logs(env):
     screen.erase()
     screen.border(0)
     if env.is_logs_mode():
-        screen.attron(curses.color_pair(COL_BORDER))
+        screen.attron(curses.color_pair(clr.COL_BORDER))
         screen.border(0)
-        screen.attroff(curses.color_pair(COL_BORDER))
+        screen.attroff(curses.color_pair(clr.COL_BORDER))
     else:
         screen.border(0)
 
@@ -1052,17 +1054,17 @@ def show_logs(env):
 
             # set color according to message type
             if str(m_type).lower().strip() in ["e", "error"]:
-                m_col = curses.color_pair(COL_RED)
+                m_col = curses.color_pair(clr.COL_RED)
             elif str(m_type).lower().strip() in ["i", "info"]:
                 m_col = curses.A_NORMAL
             elif str(m_type).lower().strip() in ["w", "warning"]:
-                m_col = curses.color_pair(COL_BLUE)
+                m_col = curses.color_pair(clr.COL_BLUE)
             else:
                 m_col = curses.A_NORMAL
 
             data_to_print = [str(date), " | ", str(m_type), " | ", str(message)]
             data_colors = [
-                curses.color_pair(COL_YELLOW),
+                curses.color_pair(clr.COL_YELLOW),
                 curses.A_NORMAL,
                 m_col,
                 curses.A_NORMAL,
@@ -1092,6 +1094,6 @@ def show_logs(env):
         env.user_logs_printed_shift = win.row_shift
 
     except Exception as err:
-        log("show logs | " + str(err) + " | " + str(traceback.format_exc()))
+        logger.log("show logs | " + str(err) + " | " + str(traceback.format_exc()))
     finally:
         screen.refresh()

--- a/spef/utils/screens.py
+++ b/spef/utils/screens.py
@@ -5,9 +5,9 @@ import fcntl
 import termios
 import traceback
 
+from spef.utils.coloring import COL_BKGD
 from spef.modules.window import Windows, Screens, Window
-from spef.utils.printing import *
-from spef.utils.logger import *
+from spef.utils.logger import log
 
 
 def new_vertical_shift(old_shift, old_height, cursor, new_height):

--- a/spef/views/filtering.py
+++ b/spef/views/filtering.py
@@ -2,12 +2,13 @@ import curses
 import curses.ascii
 import traceback
 
-from spef.controls.control import *
+import spef.controls.functions as func
+from spef.controls.control import get_function_for_key
 from spef.modules.buffer import UserInput
 from spef.modules.filter import Filter
-from spef.utils.screens import *
-from spef.utils.printing import *
-from spef.utils.logger import *
+from spef.utils.screens import resize_all
+from spef.utils.printing import print_hint, show_filter, rewrite_all_wins
+from spef.utils.logger import log
 from spef.views.help import show_help
 
 
@@ -91,55 +92,55 @@ def run_function(stdscr, filter_data, old_filter_text, env, fce, key):
     screen, win, user_input = filter_data
 
     # ======================= EXIT =======================
-    if fce == EXIT_PROGRAM:
+    if fce == func.EXIT_PROGRAM:
         env.set_exit_mode()
         return filter_data, env, True
-    elif fce == EXIT_FILTER:
+    elif fce == func.EXIT_FILTER:
         return filter_data, env, True
     # ======================= RESIZE =======================
-    elif fce == RESIZE_WIN:
+    elif fce == func.RESIZE_WIN:
         env = resize_all(stdscr, env)
         screen, win = env.get_screen_for_current_mode()
         rewrite_all_wins(env)
     # ======================= SHOW HELP =======================
-    elif fce == SHOW_HELP:
+    elif fce == func.SHOW_HELP:
         show_help(stdscr, env)
         curses.curs_set(1)
     # ======================= ARROWS =======================
-    elif fce == CURSOR_UP:
+    elif fce == func.CURSOR_UP:
         user_input.pointer = 0
         user_input.col_shift = 0
-    elif fce == CURSOR_DOWN:
+    elif fce == func.CURSOR_DOWN:
         end_of_input = len(user_input)
         user_input.pointer = end_of_input
         user_input.horizontal_shift(win)
-    elif fce == CURSOR_LEFT:
+    elif fce == func.CURSOR_LEFT:
         user_input.left(win)
-    elif fce == CURSOR_RIGHT:
+    elif fce == func.CURSOR_RIGHT:
         user_input.right(win)
     # ======================= EDIT FILTER =======================
-    elif fce == DELETE_CHAR:
+    elif fce == func.DELETE_CHAR:
         user_input.delete_symbol(win)
-    elif fce == BACKSPACE_CHAR:
+    elif fce == func.BACKSPACE_CHAR:
         if user_input.pointer > 0:
             user_input.left(win)
             user_input.delete_symbol(win)
-    elif fce == PRINT_CHAR:
+    elif fce == func.PRINT_CHAR:
         user_input.insert_symbol(win, chr(key))
-    elif fce == SAVE_FILTER:
+    elif fce == func.SAVE_FILTER:
         text = "".join(user_input.text)
         env.filter.add_by_current_mode(env, text)
         env.filter.find_files(env)
         if old_filter_text != text:
             env.prepare_browsing_after_filter()
         return filter_data, env, True
-    elif fce == AGGREGATE_FILTER:
+    elif fce == func.AGGREGATE_FILTER:
         env.filter.aggregate = not env.filter.aggregate
         env.filter.find_files(env)
         env.prepare_browsing_after_filter()
         return filter_data, env, True
     # ======================= REMOVE FILTER =======================
-    elif fce == REMOVE_FILTER:
+    elif fce == func.REMOVE_FILTER:
         # env.filter.reset_by_current_mode(env)
         env.filter.reset_all()
         env.filter.find_files(env)

--- a/spef/views/help.py
+++ b/spef/views/help.py
@@ -1,10 +1,10 @@
 import curses
 import curses.ascii
 
-from spef.controls.functions import *
-from spef.utils.printing import *
-from spef.utils.screens import *
-from spef.utils.logger import *
+import spef.controls.functions as func
+from spef.utils.printing import parse_line_into_sublines, rewrite_all_wins, print_help
+from spef.utils.screens import resize_all
+from spef.utils.logger import ESC
 
 
 # return number of lines needed to print given buffer
@@ -115,10 +115,15 @@ def get_help(env):
 
     actions = {}
     for key, function in dict_functions.items():
-        if function in [CURSOR_UP, CURSOR_DOWN, CURSOR_LEFT, CURSOR_RIGHT]:
+        if function in [
+            func.CURSOR_UP,
+            func.CURSOR_DOWN,
+            func.CURSOR_LEFT,
+            func.CURSOR_RIGHT,
+        ]:
             key = "Arrows"
             function = "Arrows"
-        elif function in [DELETE_CHAR, BACKSPACE_CHAR]:
+        elif function in [func.DELETE_CHAR, func.BACKSPACE_CHAR]:
             key = "Delete, backspace"
             function = "Del"
         elif key == "SLASH":
@@ -162,57 +167,57 @@ def get_description_for_fce(env, fce):
 
     if env.is_user_input_mode():
         descr_dir = {
-            SHOW_HELP: "show this user help",
-            EXIT_PROGRAM: "exit program",
-            EXIT_USER_INPUT: "exit user input without saving",
-            BASH_SWITCH: "switch to bash",
+            func.SHOW_HELP: "show this user help",
+            func.EXIT_PROGRAM: "exit program",
+            func.EXIT_USER_INPUT: "exit user input without saving",
+            func.BASH_SWITCH: "switch to bash",
             "Arrows": "move cursor in user input",
             "Del": "delete symbol in user input",
-            PRINT_CHAR: "insert symbol in user input",
-            SAVE_INPUT: "save user input and exit",
-            MOVE_LEFT: "move window to the left",
-            MOVE_RIGHT: "move window to the right",
+            func.PRINT_CHAR: "insert symbol in user input",
+            func.SAVE_INPUT: "save user input and exit",
+            func.MOVE_LEFT: "move window to the left",
+            func.MOVE_RIGHT: "move window to the right",
         }
     elif env.is_menu_mode():
         descr_dir = {
-            SHOW_HELP: "show this user help",
-            EXIT_PROGRAM: "exit program",
-            EXIT_MENU: "exit menu",
-            BASH_SWITCH: "switch to bash",
+            func.SHOW_HELP: "show this user help",
+            func.EXIT_PROGRAM: "exit program",
+            func.EXIT_MENU: "exit menu",
+            func.BASH_SWITCH: "switch to bash",
             "Arrows": "brows between menu options",
-            SAVE_OPTION: "save current selected option",
-            SELECT_BY_IDX: "save option by index",
-            SELECT_OPTION: "select multiple options",
-            MOVE_LEFT: "move window to the left",
-            MOVE_RIGHT: "move window to the right",
+            func.SAVE_OPTION: "save current selected option",
+            func.SELECT_BY_IDX: "save option by index",
+            func.SELECT_OPTION: "select multiple options",
+            func.MOVE_LEFT: "move window to the left",
+            func.MOVE_RIGHT: "move window to the right",
         }
     elif env.is_filter_mode():
         descr_dir = {
-            SHOW_HELP: "show this user help",
-            AGGREGATE_FILTER: "aggregate by same tags file",
-            REMOVE_FILTER: "remove all filters",
-            EXIT_PROGRAM: "exit program",
-            EXIT_FILTER: "exit filter management",
-            BASH_SWITCH: "switch to bash",
+            func.SHOW_HELP: "show this user help",
+            func.AGGREGATE_FILTER: "aggregate by same tags file",
+            func.REMOVE_FILTER: "remove all filters",
+            func.EXIT_PROGRAM: "exit program",
+            func.EXIT_FILTER: "exit filter management",
+            func.BASH_SWITCH: "switch to bash",
             "Arrows": "move cursor in user input",
             "Del": "delete symbol in user input",
-            PRINT_CHAR: "insert symbol in user input",
-            SAVE_FILTER: "set filter and exit filter management",
+            func.PRINT_CHAR: "insert symbol in user input",
+            func.SAVE_FILTER: "set filter and exit filter management",
         }
     elif env.is_brows_mode():
         descr_dir = {
-            SHOW_HELP: "show this user help",
-            OPEN_MENU: "open menu with other functions",
-            QUICK_VIEW_ON_OFF: "set quick view mode on/off",
-            OPEN_FILE: "open file for edit",
-            GO_TO_TAGS: "change focus to tags",
-            SHOW_OR_HIDE_CACHED_FILES: "show/hide cached files (tags, report)",
-            SHOW_OR_HIDE_LOGS: "show/hide logs for user",
-            DELETE_FILE: "delete selected file",
-            EXIT_PROGRAM: "exit program",
-            CHANGE_FOCUS: "change focus to file view/edit",
-            BASH_SWITCH: "switch to bash",
-            FILTER: "set filter by path",
+            func.SHOW_HELP: "show this user help",
+            func.OPEN_MENU: "open menu with other functions",
+            func.QUICK_VIEW_ON_OFF: "set quick view mode on/off",
+            func.OPEN_FILE: "open file for edit",
+            func.GO_TO_TAGS: "change focus to tags",
+            func.SHOW_OR_HIDE_CACHED_FILES: "show/hide cached files (tags, report)",
+            func.SHOW_OR_HIDE_LOGS: "show/hide logs for user",
+            func.DELETE_FILE: "delete selected file",
+            func.EXIT_PROGRAM: "exit program",
+            func.CHANGE_FOCUS: "change focus to file view/edit",
+            func.BASH_SWITCH: "switch to bash",
+            func.FILTER: "set filter by path",
             "Arrows": "brows between files and dirs",
         }
     elif env.is_view_mode():
@@ -223,66 +228,68 @@ def get_description_for_fce(env, fce):
         else:
             tab_action = "directory browsing"
         descr_dir = {
-            SHOW_HELP: "show this user help",
-            SAVE_FILE: "save file changes",
-            SHOW_OR_HIDE_TAGS: "show/hide tags",
-            SHOW_OR_HIDE_LINE_NUMBERS: "show/hide line numbers",
-            SHOW_OR_HIDE_NOTE_HIGHLIGHT: "show/hide note highlight",
-            OPEN_NOTE_MANAGEMENT: "open note management",
-            RELOAD_FILE_FROM_LAST_SAVE: "reload file content from last save",
-            SHOW_TYPICAL_NOTES: "show typical notes",
-            EXIT_PROGRAM: "exit program",
-            CHANGE_FOCUS: f"change focus to {tab_action}",
-            BASH_SWITCH: "switch to bash",
-            FILTER: "set filter by content",
+            func.SHOW_HELP: "show this user help",
+            func.SAVE_FILE: "save file changes",
+            func.SHOW_OR_HIDE_TAGS: "show/hide tags",
+            func.SHOW_OR_HIDE_LINE_NUMBERS: "show/hide line numbers",
+            func.SHOW_OR_HIDE_NOTE_HIGHLIGHT: "show/hide note highlight",
+            func.OPEN_NOTE_MANAGEMENT: "open note management",
+            func.RELOAD_FILE_FROM_LAST_SAVE: "reload file content from last save",
+            func.SHOW_TYPICAL_NOTES: "show typical notes",
+            func.EXIT_PROGRAM: "exit program",
+            func.CHANGE_FOCUS: f"change focus to {tab_action}",
+            func.BASH_SWITCH: "switch to bash",
+            func.FILTER: "set filter by content",
             "Arrows": "move cursor in file content",
-            SET_MANAGE_FILE_MODE: "set manage file mode",
-            SET_EDIT_FILE_MODE: "set edit file mode",
-            ADD_CUSTOM_NOTE: "add custom note to current line",
-            ADD_TYPICAL_NOTE: "add typical note to current line",
-            PRINT_CHAR: "insert symbol in file on current cursor position",
-            PRINT_NEW_LINE: "insert new line in file on current cursor position",
+            func.SET_MANAGE_FILE_MODE: "set manage file mode",
+            func.SET_EDIT_FILE_MODE: "set edit file mode",
+            func.ADD_CUSTOM_NOTE: "add custom note to current line",
+            func.ADD_TYPICAL_NOTE: "add typical note to current line",
+            func.PRINT_CHAR: "insert symbol in file on current cursor position",
+            func.PRINT_NEW_LINE: "insert new line in file on current cursor position",
             "Del": "delete symbol in file on current cursor position",
-            GO_TO_PREV_NOTE: "jump to line with previous note in file",
-            GO_TO_NEXT_NOTE: "jump to line with next note in file",
-            RELOAD_ORIGINAL_BUFF: "reload file content from original buffer",
+            func.GO_TO_PREV_NOTE: "jump to line with previous note in file",
+            func.GO_TO_NEXT_NOTE: "jump to line with next note in file",
+            func.RELOAD_ORIGINAL_BUFF: "reload file content from original buffer",
         }
         if env.editing_test_file:
             descr_dir.update(
-                {SHOW_SUPPORTED_DATA: "show supported bash functions for 'dotest.sh'"}
+                {
+                    func.SHOW_SUPPORTED_DATA: "show supported bash functions for 'dotest.sh'"
+                }
             )
         elif env.editing_report_template:
             descr_dir.update(
-                {SHOW_SUPPORTED_DATA: "show supported data for report template"}
+                {func.SHOW_SUPPORTED_DATA: "show supported data for report template"}
             )
     elif env.is_tag_mode():
         descr_dir = {
-            SHOW_HELP: "show this user help",
-            EDIT_TAG: "edit current tag",
-            ADD_TAG: "create new tag",
-            OPEN_TAG_FILE: "open file with tags for edit",
-            DELETE_TAG: "delete current tag",
-            EXIT_PROGRAM: "exit program",
-            CHANGE_FOCUS: "change focus to directory browsing",
-            BASH_SWITCH: "switch to bash",
-            FILTER: "set filter by tag",
+            func.SHOW_HELP: "show this user help",
+            func.EDIT_TAG: "edit current tag",
+            func.ADD_TAG: "create new tag",
+            func.OPEN_TAG_FILE: "open file with tags for edit",
+            func.DELETE_TAG: "delete current tag",
+            func.EXIT_PROGRAM: "exit program",
+            func.CHANGE_FOCUS: "change focus to directory browsing",
+            func.BASH_SWITCH: "switch to bash",
+            func.FILTER: "set filter by tag",
             "Arrows": "brows between tags",
         }
     elif env.is_notes_mode():
         descr_dir = {
-            SHOW_HELP: "show this user help",
-            EDIT_NOTE: "edit current note",
-            SHOW_TYPICAL_NOTES: "show typical notes",
-            GO_TO_NOTE: "go to current note in file",
-            SAVE_AS_TYPICAL_NOTE: "save note as typical",
-            DELETE_NOTE: "delete current note",
-            EXIT_PROGRAM: "exit program",
-            EXIT_NOTES: "exit note management",
-            CHANGE_FOCUS: "change focus to file view/edit",
-            BASH_SWITCH: "switch to bash",
+            func.SHOW_HELP: "show this user help",
+            func.EDIT_NOTE: "edit current note",
+            func.SHOW_TYPICAL_NOTES: "show typical notes",
+            func.GO_TO_NOTE: "go to current note in file",
+            func.SAVE_AS_TYPICAL_NOTE: "save note as typical",
+            func.DELETE_NOTE: "delete current note",
+            func.EXIT_PROGRAM: "exit program",
+            func.EXIT_NOTES: "exit note management",
+            func.CHANGE_FOCUS: "change focus to file view/edit",
+            func.BASH_SWITCH: "switch to bash",
             "Arrows": "brows between notes",
-            ADD_CUSTOM_NOTE: "add custom note",
-            ADD_TYPICAL_NOTE: "add typical notes",
+            func.ADD_CUSTOM_NOTE: "add custom note",
+            func.ADD_TYPICAL_NOTE: "add typical notes",
         }
 
     if fce in descr_dir:

--- a/spef/views/input.py
+++ b/spef/views/input.py
@@ -2,11 +2,13 @@ import curses
 import curses.ascii
 import traceback
 
-from spef.controls.control import *
+from spef.utils.coloring import COL_GREEN
+import spef.controls.functions as func
+from spef.controls.control import get_function_for_key
 from spef.modules.buffer import UserInput
-from spef.utils.printing import *
-from spef.utils.screens import *
-from spef.utils.logger import *
+from spef.utils.printing import rewrite_all_wins, show_user_input
+from spef.utils.screens import resize_all
+from spef.utils.logger import log
 from spef.views.help import show_help
 
 
@@ -61,17 +63,17 @@ def run_function(stdscr, user_input, env, fce, key):
     old_position = win.position
 
     # ======================= EXIT =======================
-    if fce == EXIT_PROGRAM:
+    if fce == func.EXIT_PROGRAM:
         rewrite_all_wins(env)
         env.set_exit_mode()
         user_input.text = None
         return user_input, env, True
-    elif fce == EXIT_USER_INPUT:
+    elif fce == func.EXIT_USER_INPUT:
         rewrite_all_wins(env)
         user_input.text = None
         return user_input, env, True
     # ======================= RESIZE =======================
-    elif fce == RESIZE_WIN:
+    elif fce == func.RESIZE_WIN:
         env = resize_all(stdscr, env)
         screen, win = env.get_center_win()
         win.reset()
@@ -79,42 +81,42 @@ def run_function(stdscr, user_input, env, fce, key):
         rewrite_all_wins(env)
         curses.curs_set(1)
     # ======================= SHOW HELP =======================
-    elif fce == SHOW_HELP:
+    elif fce == func.SHOW_HELP:
         show_help(stdscr, env)
         curses.curs_set(1)
     # ========================= ARROWS =========================
-    elif fce == CURSOR_UP:  # TODO: Fix
+    elif fce == func.CURSOR_UP:  # TODO: Fix
         user_input.pointer = 0
         user_input.col_shift = 0
-    elif fce == CURSOR_DOWN:  # TODO: Fix
+    elif fce == func.CURSOR_DOWN:  # TODO: Fix
         end_of_input = len(user_input)
         user_input.pointer = end_of_input
         user_input.horizontal_shift(win)
-    elif fce == CURSOR_LEFT:
+    elif fce == func.CURSOR_LEFT:
         user_input.left(win)
-    elif fce == CURSOR_RIGHT:
+    elif fce == func.CURSOR_RIGHT:
         user_input.right(win)
     # ======================== INPUT ========================
-    elif fce == DELETE_CHAR:
+    elif fce == func.DELETE_CHAR:
         user_input.delete_symbol(win)
-    elif fce == BACKSPACE_CHAR:
+    elif fce == func.BACKSPACE_CHAR:
         if user_input.pointer > 0:
             user_input.left(win)
             user_input.delete_symbol(win)
-    elif fce == SAVE_INPUT:
+    elif fce == func.SAVE_INPUT:
         rewrite_all_wins(env)
         return user_input, env, True
-    elif fce == PRINT_CHAR:
+    elif fce == func.PRINT_CHAR:
         user_input.insert_symbol(win, chr(key))
     # ========================= MOVE WIN =========================
-    elif fce == MOVE_LEFT:
+    elif fce == func.MOVE_LEFT:
         if old_position == 2:
             win.set_position(1, screen)
         elif old_position == 3:
             win.set_position(2, screen)
         rewrite_all_wins(env)
         curses.curs_set(1)
-    elif fce == MOVE_RIGHT:
+    elif fce == func.MOVE_RIGHT:
         if old_position == 1:
             win.set_position(2, screen)
         elif old_position == 2:

--- a/spef/views/menu.py
+++ b/spef/views/menu.py
@@ -2,10 +2,12 @@ import curses
 import curses.ascii
 import traceback
 
-from spef.controls.control import *
-from spef.utils.printing import *
-from spef.utils.screens import *
-from spef.utils.logger import *
+import spef.controls.functions as func
+from spef.utils.coloring import COL_GREEN
+from spef.controls.control import get_function_for_key
+from spef.utils.printing import rewrite_all_wins, show_menu
+from spef.utils.screens import resize_all
+from spef.utils.logger import log
 from spef.views.help import show_help
 
 
@@ -81,15 +83,15 @@ def run_function(stdscr, menu_data, selected_options, env, fce, key):
     keys_list, menu_options, select_multiple = menu_data
 
     # ======================= EXIT =======================
-    if fce == EXIT_PROGRAM:
+    if fce == func.EXIT_PROGRAM:
         rewrite_all_wins(env)
         env.set_exit_mode()
         return None, env, True
-    elif fce == EXIT_MENU:
+    elif fce == func.EXIT_MENU:
         rewrite_all_wins(env)
         return None, env, True
     # ======================= RESIZE =======================
-    elif fce == RESIZE_WIN:
+    elif fce == func.RESIZE_WIN:
         old_shift, old_row = win.row_shift, win.cursor.row - win.row_shift
         env = resize_all(stdscr, env)
         screen, win = env.get_center_win(reset=True, row=0, col=0)
@@ -99,22 +101,22 @@ def run_function(stdscr, menu_data, selected_options, env, fce, key):
         win.set_border(0)
         rewrite_all_wins(env)
     # ======================= SHOW HELP =======================
-    elif fce == SHOW_HELP:
+    elif fce == func.SHOW_HELP:
         show_help(stdscr, env)
         curses.curs_set(1)
     # ========================= ARROWS =========================
-    elif fce == CURSOR_UP:
+    elif fce == func.CURSOR_UP:
         win.up(menu_options, use_restrictions=False)
-    elif fce == CURSOR_DOWN:
+    elif fce == func.CURSOR_DOWN:
         win.down(menu_options, use_restrictions=False)
     # ====================== SELECT OPTION ======================
-    elif fce == SAVE_OPTION:
+    elif fce == func.SAVE_OPTION:
         if select_multiple:
             return selected_options, env, True
         else:
             option = win.cursor.row
             return option, env, True
-    elif fce == SELECT_BY_IDX:
+    elif fce == func.SELECT_BY_IDX:
         if keys_list is not None:
             char_key = chr(key)
             if char_key in keys_list:
@@ -130,18 +132,18 @@ def run_function(stdscr, menu_data, selected_options, env, fce, key):
                         selected_options.append(option)
                     else:
                         return option, env, True
-    elif fce == SELECT_OPTION:
+    elif fce == func.SELECT_OPTION:
         if select_multiple:
             option = win.cursor.row
             selected_options.append(option)
     # ========================= MOVE WIN =========================
-    elif fce == MOVE_LEFT:
+    elif fce == func.MOVE_LEFT:
         if old_position == 2:
             win.set_position(1, screen)
         elif old_position == 3:
             win.set_position(2, screen)
         rewrite_all_wins(env)
-    elif fce == MOVE_RIGHT:
+    elif fce == func.MOVE_RIGHT:
         if old_position == 1:
             win.set_position(2, screen)
         elif old_position == 2:

--- a/spef/views/tags.py
+++ b/spef/views/tags.py
@@ -3,14 +3,14 @@ import curses.ascii
 import shlex
 import traceback
 
-from spef.controls.control import *
-
+import spef.controls.functions as func
+from spef.controls.control import get_function_for_key
 from spef.modules.buffer import UserInput
 from spef.modules.bash import Bash_action
 from spef.utils.loading import save_tags_to_file
-from spef.utils.screens import *
-from spef.utils.printing import *
-from spef.utils.logger import *
+from spef.utils.screens import resize_all
+from spef.utils.printing import rewrite_all_wins
+from spef.utils.logger import log
 from spef.views.filtering import filter_management
 from spef.views.help import show_help
 from spef.views.input import get_user_input
@@ -51,37 +51,37 @@ def run_function(stdscr, env, fce, key):
     screen, win = env.get_screen_for_current_mode()
 
     # ======================= EXIT =======================
-    if fce == EXIT_PROGRAM:
+    if fce == func.EXIT_PROGRAM:
         save_tags_to_file(env.tags)
         env.set_exit_mode()
         return env, True
     # ======================= BASH =======================
-    elif fce == BASH_SWITCH:
+    elif fce == func.BASH_SWITCH:
         hex_key = "{0:x}".format(key)
         env.bash_action = Bash_action()
         env.bash_action.set_exit_key(("0" if len(hex_key) % 2 else "") + str(hex_key))
         env.bash_active = True
         return env, True
     # ======================= FOCUS =======================
-    elif fce == CHANGE_FOCUS:
+    elif fce == func.CHANGE_FOCUS:
         save_tags_to_file(env.tags)
         env.switch_to_next_mode()
         return env, True
     # ======================= RESIZE =======================
-    elif fce == RESIZE_WIN:
+    elif fce == func.RESIZE_WIN:
         env = resize_all(stdscr, env)
         screen, win = env.get_screen_for_current_mode()
     # ======================= ARROWS =======================
-    elif fce == CURSOR_UP:
+    elif fce == func.CURSOR_UP:
         win.up(env.tags, use_restrictions=False)
-    elif fce == CURSOR_DOWN:
+    elif fce == func.CURSOR_DOWN:
         win.down(env.tags, filter_on=env.tag_filter_on(), use_restrictions=False)
     # ======================= SHOW HELP =======================
-    elif fce == SHOW_HELP:
+    elif fce == func.SHOW_HELP:
         show_help(stdscr, env)
         curses.curs_set(0)
     # ======================= EDIT TAG =======================
-    elif fce == EDIT_TAG:
+    elif fce == func.EDIT_TAG:
         # get current tag
         tag_name, old_args = env.tags.get_tag_by_idx(win.cursor.row)
 
@@ -114,7 +114,7 @@ def run_function(stdscr, env, fce, key):
                         env.tags.set_tag(tag_name, old_args)
                     save_tags_to_file(env.tags)
     # ======================= ADD TAG =======================
-    elif fce == ADD_TAG:
+    elif fce == func.ADD_TAG:
         title = "Enter new tag in format: tag_name param1 param2 ..."
         env, text = get_user_input(stdscr, env, title=title)
         if env.is_exit_mode():
@@ -130,15 +130,15 @@ def run_function(stdscr, env, fce, key):
                 env.tags.set_tag(tag_name, args)
                 save_tags_to_file(env.tags)
     # ======================= OPEN FILE TAG =======================
-    elif fce == OPEN_TAG_FILE:
+    elif fce == func.OPEN_TAG_FILE:
         pass
     # ======================= DELETE TAG =======================
-    elif fce == DELETE_TAG:
+    elif fce == func.DELETE_TAG:
         env.tags.remove_tag_by_idx(win.cursor.row)
         save_tags_to_file(env.tags)
         win.up(env.tags, use_restrictions=False)
     # ======================= FILTER =======================
-    elif fce == FILTER:
+    elif fce == func.FILTER:
         env = filter_management(stdscr, screen, win, env)
         if env.is_exit_mode() or env.is_brows_mode():
             return env, True


### PR DESCRIPTION
Wildcard imports are considered a bad practice in most scenarios. This PR fixes current wildcard imports such that all imports are now either explicit (i.e., from spef.Y import X) or qualified (i.e., import spef.Y as Y). This facilitates easier maintainability of the project.

This PR fixes #10 .